### PR TITLE
relax parsing of size validation

### DIFF
--- a/encoding/asn1/asn1.go
+++ b/encoding/asn1/asn1.go
@@ -499,16 +499,6 @@ func parseTagAndLength(bytes []byte, initOffset int) (ret tagAndLength, offset i
 			}
 			ret.length <<= 8
 			ret.length |= int(b)
-			if ret.length == 0 {
-				// DER requires that lengths be minimal.
-				err = StructuralError{"superfluous leading zeros in length"}
-				return
-			}
-		}
-		// Short lengths must be encoded in short form.
-		if ret.length < 0x80 {
-			err = StructuralError{"non-minimal length"}
-			return
 		}
 	}
 


### PR DESCRIPTION
rather than pedantically check for lengths to be in minimum form, parse
them if they are parseable.

NetApp's encoding with SPNEGO dumbly encodes _all_ size values as 02 HH
LL regardless of size. This may be in violation of ASN.1, but it doesn't
break Windows so doubtful NetApp would be in any hurry to fix it.

I've left the base128 side of things alone.